### PR TITLE
Fix: alocação do valor para contar troco de notas de 2

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -41,7 +41,7 @@ class Troco {
         while (valor % 2 != 0) {
             count++;
         }
-        papeisMoeda[1] = new PapelMoeda(2, count);
+        papeisMoeda[0] = new PapelMoeda(2, count);
     }
 
     public Iterator<PapelMoeda> getIterator() {


### PR DESCRIPTION
O código está colocando a quantidade de cédulas da nota 2 na variável que armazena o troco da nota 5. Com isso o software irá entregar o troco errado