### PR TITLE
Caso de ambiguidade na seção Requisitos

### DIFF
--- a/Documentação para Wiki/Documentacao.md
+++ b/Documentação para Wiki/Documentacao.md
@@ -2,7 +2,7 @@
 
 # 1  Requisitos
 
-As estações de trem frequentemente fornecem máquinas de vender bilhetes que imprimem um bilhete quando um cliente insere a quantia correta para pagar a passagem e caso seja inserido um valor maior o usuário pode solicitar o troco. As máquinas mantêm uma soma total da quantidade de dinheiro que coletou durante toda sua operação
+As estações de trem frequentemente fornecem máquinas de vender bilhetes que imprimem um bilhete quando um cliente insere a quantia correta para pagar a passagem e caso seja inserido um valor maior o usuário pode solicitar o troco. As máquinas mantêm uma soma total da quantidade de dinheiro que coletou durante toda sua operação (sessão por usuário).
 
 ## 1.1 Catálogo dos Atores
 


### PR DESCRIPTION
Na frase "As máquinas mantêm uma soma total da quantidade de dinheiro que coletou durante toda sua operação." no requisitos, ao ler não é possível dizer se máquina deve armazenar o valor total ou armazenar a soma de dinheiro inserido na máquina por uso de um cliente